### PR TITLE
add gitattributes export-ignore support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,28 +12,46 @@ The script is compatible with Python 2.7 and 3+.
 
 ## Prerequisites
 
-- Your addon files must be located in a separate addon directory, e.g.
- `/plugin.video.example` inside your Git repository. That is, your Git repo for
-  the addon must have the following layout:
-  ```
-  /<git-repo-directory>/
-  |
-  +--/plugin.video.example/
-  |  |
-  |  +--/resources/
-  |  |  |
-  |  |  ...
-  |  +--addon.xml
-  |  +--fanart.jpg
-  |  +--icon.png
-  |
-  +--.gitignore
-  +--.travis.yml
-  +--Readme.md
-  ```
-  Such layout is preferable over "everything in the repo root directory"
-  approach because it allows not to pollute your addon directory with unnecessary
-  files, such as `.gitignore`, `.travis.yml` etc.
+- Your addon files must have one of the following formats
+  - Your addon files must be located in the root directory inside your Git repository.
+    That is, your Git repo for the addon must have the following layout:
+    ```
+    /<git-repo-directory>/
+    |
+    |
+    +--/resources/
+    |  |
+    |  ...
+    +--addon.xml
+    +--fanart.jpg
+    +--icon.png
+    |
+    +--.gitignore
+    +--.travis.yml
+    +--Readme.md
+    ```
+    To not pollute your addon submission with unnecessary files, such as `.gitignore`, `.travis.yml` etc.
+    those can be exluded by using git-archive and setting the [export-ignore attribute]
+    (https://git-scm.com/docs/gitattributes#_creating_an_archive).
+  - Your addon files must be located in a separate addon directory, e.g.
+   `/plugin.video.example` inside your Git repository. That is, your Git repo for
+    the addon must have the following layout:
+    ```
+    /<git-repo-directory>/
+    |
+    +--/plugin.video.example/
+    |  |
+    |  +--/resources/
+    |  |  |
+    |  |  ...
+    |  +--addon.xml
+    |  +--fanart.jpg
+    |  +--icon.png
+    |
+    +--.gitignore
+    +--.travis.yml
+    +--Readme.md
+    ```
 - Fork the necessary addon repository -- `xbmc/repo-plugins` or
   `xbmc/repo-scripts` -- into your GitHub account.
 - Define the following environment variables in your CI environment:
@@ -70,6 +88,7 @@ Run `submit-addon` script with the following options:
   official Kodi addon repository, if it does not exist. If the pull request
   already exists, the script will simply update the addon branch in your
   repository fork.
+- `-s`, `--subdirectory`: The addon files are located in a separate directory
 
 Example:
 ```bash

--- a/addon_submitter/__main__.py
+++ b/addon_submitter/__main__.py
@@ -32,7 +32,7 @@ def main():
     )
     if args.zip:
         utils.create_zip(
-            args.addon_id + '-' + addon_info.version, work_dir, args.addon_id
+            args.addon_id + '-' + addon_info.version, args.addon_id
         )
     if args.push_branch or args.pull_request:
         if not (args.repo and args.branch):

--- a/addon_submitter/__main__.py
+++ b/addon_submitter/__main__.py
@@ -22,17 +22,18 @@ def parse_arguments():
                         help='Push addon branch to addon repo fork')
     parser.add_argument('--pull-request', action='store_true',
                         help='Create a pull request')
+    parser.add_argument('-s', '--subdirectory', action='store_true')
     return parser.parse_args()
 
 
 def main():
     args = parse_arguments()
     addon_info = utils.get_addon_info(
-        os.path.join(work_dir, args.addon_id, 'addon.xml')
+        os.path.join(work_dir, args.addon_id if args.subdirectory else '', 'addon.xml')
     )
     if args.zip:
         utils.create_zip(
-            args.addon_id + '-' + addon_info.version, args.addon_id
+            args.addon_id + '-' + addon_info.version, args.addon_id, args.subdirectory
         )
     if args.push_branch or args.pull_request:
         if not (args.repo and args.branch):
@@ -40,7 +41,7 @@ def main():
                 'Both --repo and --branch arguments must not defined!'
             )
         utils.create_addon_branch(
-            work_dir, args.repo, args.branch, args.addon_id, addon_info.version
+            work_dir, args.repo, args.branch, args.addon_id, addon_info.version, args.subdirectory
         )
     if args.pull_request:
         utils.create_pull_request(

--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -31,16 +31,21 @@ class AddonSubmissionError(Exception):
     pass
 
 
-def create_zip(zip_name, addon_id):
+def create_zip(zip_name, addon_id, subdirectory):
     """Create a .zip for an addon
     
     :param zip_name: .zip file name
     :type zip_name: str
     :param addon_id: addon_id ID
     :type addon_id: str
+    :param subdirectory:
+    :type addon_id: bool
     """
     logger.info('Creating ZIP file...')
-    shell('git', 'archive', '-o', '{}.zip'.format(zip_name), 'HEAD', '--', addon_id)
+    if subdirectory:
+        shell('git', 'archive', '-o', '{}.zip'.format(zip_name), 'HEAD', '--', addon_id)
+    else:
+        shell('git', 'archive', '-o', '{}.zip'.format(zip_name), '--prefix', '{}/'.format(addon_id), 'HEAD')
     logger.info('ZIP created successfully.')
 
 
@@ -82,7 +87,7 @@ def shell(*args, check=True):
             subprocess.call(args, stdout=devnull, stderr=devnull)
 
 
-def create_addon_branch(work_dir, repo, branch, addon_id, version):
+def create_addon_branch(work_dir, repo, branch, addon_id, version, subdirectory):
     """ Create and addon branch in your fork of the respective addon repo
 
     :param work_dir: working directory
@@ -91,6 +96,7 @@ def create_addon_branch(work_dir, repo, branch, addon_id, version):
         e.g. 'leia'
     :param addon_id: addon ID, e.g. 'plugin.video.example'
     :param version: addon version
+    :param subdirectory: 
     """
     logger.info('Creatind addon branch...')
     gh_username = os.environ['GH_USERNAME']
@@ -110,7 +116,10 @@ def create_addon_branch(work_dir, repo, branch, addon_id, version):
     shell('git', 'checkout', '-b', addon_id, 'upstream/{}'.format(branch))
     shutil.rmtree(os.path.join(work_dir, repo, addon_id), ignore_errors=True)
     os.chdir('..')
-    shell('sh', '-c', 'git archive --format tgz HEAD -- {} | tar zxf - -C {}'.format(addon_id, repo_dir))
+    if subdirectory:
+        shell('sh', '-c', 'git archive --format tgz HEAD -- {} | tar zxf - -C {}'.format(addon_id, repo_dir))
+    else:
+        shell('sh', '-c', 'git archive --format tgz HEAD --prefix {}/ | tar zxf - -C {}'.format(addon_id, repo_dir))
     os.chdir(repo)
     shell('git', 'add', '--', addon_id)
     shell(

--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -127,17 +127,11 @@ def create_addon_branch(work_dir, repo, branch, addon_id, version):
     repo_dir = os.path.join(work_dir, repo)
     if os.path.exists(repo_dir):
         shutil.rmtree(repo_dir)
-    shell('git', 'clone', repo_fork)
+    shell('git', 'clone', '--branch', branch, '--origin', 'upstream', '--single-branch', 'git://github.com/xbmc/{}.git'.format(repo))
     os.chdir(repo)
     shell('git', 'config', 'user.name', '{}'.format(gh_username))
     shell('git', 'config', 'user.email', email)
-    shell('git', 'remote', 'add', 'upstream',
-          'https://github.com/xbmc/{}.git'.format(repo))
-    shell('git', 'fetch', 'upstream')
-    shell('git', 'checkout', '-b', branch, '--track', 'origin/' + branch)
-    shell('git', 'merge', 'upstream/' + branch)
-    shell('git', 'branch', '-D', addon_id, check=False)
-    shell('git', 'checkout', '-b', addon_id)
+    shell('git', 'checkout', '-b', addon_id, 'upstream/{}'.format(branch))
     clean_pyc(os.path.join(work_dir, addon_id))
     shutil.rmtree(os.path.join(work_dir, repo, addon_id), ignore_errors=True)
     shutil.copytree(
@@ -148,7 +142,7 @@ def create_addon_branch(work_dir, repo, branch, addon_id, version):
         'git', 'commit',
         '-m', '[{}] {}'.format(addon_id, version)
     )
-    shell('git', 'push', '-f', '-q', 'origin', addon_id)
+    shell('git', 'push', '-f', '-q', repo_fork, addon_id)
     logger.info('Addon branch created successfully.')
 
 

--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -52,19 +52,16 @@ def clean_pyc(directory):
     os.chdir(cwd)
 
 
-def create_zip(zip_name, work_dir, addon_id):
+def create_zip(zip_name, addon_id):
     """Create a .zip for an addon
     
     :param zip_name: .zip file name
     :type zip_name: str
-    :param work_dir: working directory
-    :type work_dir: str
     :param addon_id: addon_id ID
     :type addon_id: str
     """
     logger.info('Creating ZIP file...')
-    clean_pyc(os.path.join(work_dir, addon_id))
-    shutil.make_archive(zip_name, 'zip', root_dir=work_dir, base_dir=addon_id)
+    shell('git', 'archive', '-o', '{}.zip'.format(zip_name), 'HEAD', '--', addon_id)
     logger.info('ZIP created successfully.')
 
 

--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -129,7 +129,7 @@ def create_addon_branch(work_dir, repo, branch, addon_id, version):
         shutil.rmtree(repo_dir)
     shell('git', 'clone', repo_fork)
     os.chdir(repo)
-    shell('git', 'config', 'user.name', '"{}"'.format(gh_username))
+    shell('git', 'config', 'user.name', '{}'.format(gh_username))
     shell('git', 'config', 'user.email', email)
     shell('git', 'remote', 'add', 'upstream',
           'https://github.com/xbmc/{}.git'.format(repo))


### PR DESCRIPTION
This adds support for defining files not meant for submission via .gitattributes (https://git-scm.com/docs/gitattributes#_creating_an_archive)

It also makes the separate addon directory obsolete, which causes that zip files generated from GitHub can't be directly installed in Kodi for testing.