### PR TITLE
Automate personal forks

### DIFF
--- a/addon_submitter/__main__.py
+++ b/addon_submitter/__main__.py
@@ -41,9 +41,15 @@ def main():
             raise utils.AddonSubmissionError(
                 'Both --repo and --branch arguments must not defined!'
             )
+
+        # fork the repo if the user does not have a personal repo fork
+        if not utils.user_fork_exists(args.repo):
+            utils.create_personal_fork(args.repo)
+
         utils.create_addon_branch(
             work_dir, args.repo, args.branch, args.addon_id, addon_info.version, args.subdirectory
         )
+
     if args.pull_request:
         utils.create_pull_request(
             args.repo, args.branch, args.addon_id, addon_info


### PR DESCRIPTION
While using the tool with https://github.com/xbmc/action-kodi-addon-submitter with a github account other than mine, I found that the submission only worked if I manually forked the xbmc addon repo project with that account. 
Since the goal of the tool is to automate the submission, I added the required steps to validate the user has already a fork and the creation of the fork itself.

Forking in github is an async task and should take a maximum (worst case scenario) of 5 minutes. Hence I sleep for 20 seconds between verifications considering the 5 minutes as the maximum timeout interval.