### PR TITLE
Fix exception raising if forking is successful

### DIFF
--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -178,7 +178,7 @@ def create_personal_fork(repo):
             time.sleep(20)
             elapsed_time += 20
         else:
-            break;
+            return
     raise AddonSubmissionError("Timeout waiting for fork creation exceeded")
 
 


### PR DESCRIPTION
Sorry @romanvm 
If the forking is successful we must return early otherwise we always reach the exception