### PR TITLE
Also create zip distribution packages for matrix

### DIFF
--- a/addon_submitter/__main__.py
+++ b/addon_submitter/__main__.py
@@ -25,23 +25,39 @@ def parse_arguments():
     parser.add_argument('-s', '--subdirectory', action='store_true',
                         help='Addon is stored in its own directory within the git repo')
     parser.add_argument('-m', '--matrix', action='store_true',
-                        help='Submit to the matrix branch as well')
+                        help='Submit to the matrix branch as well if --pull-request or '\
+                             '--push-branch or create an addition zip file for matrix if --matrix')
     return parser.parse_args()
 
 
 def main():
     args = parse_arguments()
     addon_xml_path = os.path.join(work_dir, args.addon_id if args.subdirectory else '', 'addon.xml')
+    addon_xml_originalcontent = utils.get_addonxml_content(addon_xml_path)
     addon_info = utils.get_addon_info(addon_xml_path)
+
     if args.zip:
         utils.create_zip(
             args.addon_id + '-' + addon_info.version, args.addon_id, args.subdirectory
         )
+        if args.matrix:
+            utils.modify_addon_xml_for_matrix(addon_xml_path)
+            addon_info = utils.get_addon_info(addon_xml_path)
+            utils.create_zip(
+                args.addon_id + '-' + addon_info.version, args.addon_id, args.subdirectory
+            )
+            # restore addon.xml original content
+            utils.write_addonxml(addon_xml_path, addon_xml_originalcontent)
+
     if args.push_branch or args.pull_request:
+
         if not (args.repo and args.branch):
             raise utils.AddonSubmissionError(
                 'Both --repo and --branch arguments must not defined!'
             )
+
+        # restore addon info (a zip modifying addon.xml might have been created before)
+        addon_info = utils.get_addon_info(addon_xml_path)
 
         # fork the repo if the user does not have a personal repo fork
         if not utils.user_fork_exists(args.repo):
@@ -51,24 +67,24 @@ def main():
             work_dir, args.repo, args.branch, args.addon_id, addon_info.version, args.subdirectory
         )
 
-    if args.pull_request:
-        utils.create_pull_request(
-            args.repo, args.branch, args.addon_id, addon_info
-        )
-    if args.matrix:
-        os.chdir(work_dir)
-        utils.modify_addon_xml_for_matrix(addon_xml_path)
-        utils.create_git_commit('Modify versions for matrix branch')
-        addon_info = utils.get_addon_info(addon_xml_path)
-        local_branch_name = args.addon_id + '@matrix'
-        utils.create_addon_branch(
-            work_dir, args.repo, 'matrix', args.addon_id, addon_info.version, args.subdirectory,
-            local_branch_name=local_branch_name
-        )
         if args.pull_request:
             utils.create_pull_request(
-                args.repo, 'matrix', local_branch_name, addon_info
+                args.repo, args.branch, args.addon_id, addon_info
             )
+        if args.matrix:
+            os.chdir(work_dir)
+            utils.modify_addon_xml_for_matrix(addon_xml_path)
+            utils.create_git_commit('Modify versions for matrix branch')
+            addon_info = utils.get_addon_info(addon_xml_path)
+            local_branch_name = args.addon_id + '@matrix'
+            utils.create_addon_branch(
+                work_dir, args.repo, 'matrix', args.addon_id, addon_info.version, args.subdirectory,
+                local_branch_name=local_branch_name
+            )
+            if args.pull_request:
+                utils.create_pull_request(
+                    args.repo, 'matrix', local_branch_name, addon_info
+                )
 
 
 if __name__ == '__main__':

--- a/addon_submitter/utils.py
+++ b/addon_submitter/utils.py
@@ -290,6 +290,16 @@ def modify_addon_xml_for_matrix(addon_xml_path):
     matrix_addon_version_mask = r'\g<1>{}\g<3>'.format(matrix_addon_version)
     addon_xml = ADDON_VERSION_RE.sub(matrix_addon_version_mask, addon_xml)
     addon_xml = XBMC_PYTHON_VERSION_RE.sub(r'\g<1>3.0.0\g<3>', addon_xml)
+    write_addonxml(addon_xml_path, addon_xml)
+
+
+def get_addonxml_content(addon_xml_path):
+    logger.info('Getting addon.xml file content')
+    with open(addon_xml_path, 'r', encoding='utf-8') as addonxml:
+        return addonxml.read()
+
+
+def write_addonxml(addon_xml_path, addon_xml):
     with open(addon_xml_path, 'w', encoding='utf-8') as fo:
         fo.write(addon_xml)
 


### PR DESCRIPTION
Hey @romanvm 

Thanks for adding an option to create an additional pull request to matrix when tagging a new addon release. Unfortunately you seem to have forgotten the `-z` option (we should also be able to create another zip package for installation in matrix).

I use this option in https://github.com/xbmc/action-kodi-addon-submitter to upload release distribution zips to the github releases tab of the addon repository. So, with this pull request we should be able to do:

`submit-addon -z -m` and have 2 zip files created, one for the main addon and another to matrix.

I'll leave a few comments in the code