### PR TITLE
Allow submissions from different branches targetting different versions

### DIFF
--- a/addon_submitter/__main__.py
+++ b/addon_submitter/__main__.py
@@ -64,7 +64,8 @@ def main():
             utils.create_personal_fork(args.repo)
 
         utils.create_addon_branch(
-            work_dir, args.repo, args.branch, args.addon_id, addon_info.version, args.subdirectory
+            work_dir, args.repo, args.branch, args.addon_id, addon_info.version, args.subdirectory,
+            local_branch_name='{}@{}'.format(args.addon_id, args.branch)
         )
 
         if args.pull_request:
@@ -79,7 +80,7 @@ def main():
             local_branch_name = args.addon_id + '@matrix'
             utils.create_addon_branch(
                 work_dir, args.repo, 'matrix', args.addon_id, addon_info.version, args.subdirectory,
-                local_branch_name=local_branch_name
+                local_branch_name = '{}@{}'.format(args.addon_id, '@matrix')
             )
             if args.pull_request:
                 utils.create_pull_request(


### PR DESCRIPTION
Hey @romanvm,

Found another issue with the automation. If we want to maintain two versions of the same addon stored in different branches (similar to what we currently do with binary addons), the pull request to another branch will automatically close any PRs opened from another branch.
To solve this, I'm appending the target branch to the localbranch. So let's say:

We tag a release from branch "gotham" -> branch would be `plugin.video.foo@gotham`
We tag a release from branch "matrix" -> branch would be  `plugin.video.foo@matrix`

You can see an example of the problem here:

From matrix: https://github.com/xbmc/repo-scripts/pull/1436
From gotham: https://github.com/xbmc/repo-scripts/pull/1435

Gotham PR was automatically closed once the matrix one was pushed.

It would be nice to have this fixed asap so I can continue to work on porting my addons