### PR TITLE
Remove extra @ in branch name in matrix submissions

### DIFF
--- a/addon_submitter/__main__.py
+++ b/addon_submitter/__main__.py
@@ -78,7 +78,7 @@ def main():
             utils.modify_addon_xml_for_matrix(addon_xml_path)
             utils.create_git_commit('Modify versions for matrix branch')
             addon_info = utils.get_addon_info(addon_xml_path)
-            local_branch_name = '{}@{}'.format(args.addon_id, '@matrix')
+            local_branch_name = '{}@{}'.format(args.addon_id, 'matrix')
             utils.create_addon_branch(
                 work_dir, args.repo, 'matrix', args.addon_id, addon_info.version, args.subdirectory,
                 local_branch_name = local_branch_name


### PR DESCRIPTION
@romanvm last one I promise :)

This removes an extra @ that was being added in matrix submissions. See https://github.com/xbmc/repo-plugins/pulls  for reference